### PR TITLE
Use GitHub PAT token in release

### DIFF
--- a/.github/workflows/odis-combiner-container.yml
+++ b/.github/workflows/odis-combiner-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   odis-combiner-build-dev:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/odis-combiner
     if: |
       github.ref != 'refs/heads/main'
@@ -32,7 +32,7 @@ jobs:
       trivy: true
 
   odis-combiner-build:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/social-connect/odis-combiner
     if: |
       github.ref == 'refs/heads/main'
@@ -46,7 +46,7 @@ jobs:
       trivy: true
 
   odis-combiner-tag:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/social-connect/odis-combiner tag
     if: |
       startsWith(github.ref, 'refs/tags/odis-combiner-')

--- a/.github/workflows/odis-loadtest-container.yml
+++ b/.github/workflows/odis-loadtest-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   odis-loadtest-build-dev:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/odis-loadtest
     if: |
       github.ref != 'refs/heads/main'
@@ -32,7 +32,7 @@ jobs:
       trivy: true
 
   odis-loadtest-build:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/social-connect/odis-loadtest
     if: |
       github.ref == 'refs/heads/main'
@@ -46,7 +46,7 @@ jobs:
       trivy: true
 
   odis-loadtest-tag:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/social-connect/odis-loadtest tag
     if: |
       startsWith(github.ref, 'refs/tags/odis-loadtest-')

--- a/.github/workflows/odis-signer-container.yml
+++ b/.github/workflows/odis-signer-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   odis-signer-build-dev:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/dev-images/odis-signer
     if: |
       github.ref != 'refs/heads/main'
@@ -32,7 +32,7 @@ jobs:
       trivy: true
 
   odis-signer-build:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/social-connect/odis-signer
     if: |
       github.ref == 'refs/heads/main'
@@ -46,7 +46,7 @@ jobs:
       trivy: true
 
   odis-signer-tag:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.12.3
     name: Build us-west1-docker.pkg.dev/devopsre/social-connect/odis-signer tag
     if: |
       startsWith(github.ref, 'refs/tags/odis-signer-')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
           dynamic-secrets: '{
-            "/dynamic-secrets/keys/github/charts/contents=write,pull_requests=write":"PAT",
+            "/dynamic-secrets/keys/github/social-connect/contents=write,pull_requests=write":"PAT",
             "/static-secrets/apps-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
 
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,39 +13,44 @@ jobs:
     name: Release
     runs-on: ['self-hosted', 'org', 'npm-publish']
     permissions:
-      contents: write
       id-token: write
-      pull-requests: write
-      repository-projects: write
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-
-      - name: Akeyless Get Secrets
-        id: get_auth_token
+      - name: Get GitHub Token from akeyless
+        id: get_github_token
         uses:
           docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/apps-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
+          dynamic-secrets: '{
+            "/dynamic-secrets/keys/github/charts/contents=write,pull_requests=write":"PAT",
+            "/static-secrets/apps-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ env.PAT }}
+
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
+
       - name: 'Setup yarn'
         shell: bash
         run: |
           npm install --global yarn
           source ~/.bashrc
+
       - name: Install Dependencies
         shell: bash
         run: yarn
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.PAT }}
           NPM_TOKEN: ${{ env.NPM_TOKEN }}
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish

--- a/.github/workflows/social-connect.yml
+++ b/.github/workflows/social-connect.yml
@@ -51,12 +51,12 @@ jobs:
           key: git-${{ github.ref }}
           restore-keys: |
             git-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Detect files changed in PR, and expose as output
         id: changed-files
-        uses: tj-actions/changed-files@v39
+        uses: tj-actions/changed-files@v40
         with:
           # Using comma as separator to be able to easily match full paths (using ,<path>)
           separator: ','
@@ -263,7 +263,7 @@ jobs:
         with:
           path: .git
           key: git-${{ github.ref }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Sync workspace
         uses: ./.github/actions/sync-workspace
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,4 +32,3 @@ jobs:
         days-before-close: 30
         ascending: true
         operations-per-run: 50
-


### PR DESCRIPTION
### Description

Use GitHub PAT token from akeyless (dynamic secret). The reason to use a PAT instead of GITHUB_TOKEN is that by design GITHUB_TOKEN does not trigger workflows (https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)