### PR TITLE
Change NPM package aliases to prevent low socket.dev score

### DIFF
--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -43,11 +43,11 @@
     "@celo/dev-utils": "0.0.1-beta.1",
     "@celo/wallet-local": "^5.1.0",
     "@types/elliptic": "^6.4.16",
+    "celo-base-old-version": "npm:@celo/base@5.0.0",
+    "celo-identity-old-version": "npm:@celo/identity@1.5.2",
     "fetch-mock": "9.11.0",
     "ganache": "npm:@celo/ganache@7.8.0-unofficial.0",
-    "jest": "^29.7.0",
-    "@celo/base@5.0.0": "npm:@celo/base@5.0.0",
-    "@celo/identity@1.5.2": "npm:@celo/identity@1.5.2"
+    "jest": "^29.7.0"
   },
   "engines": {
     "node": ">=16"

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -46,8 +46,8 @@
     "fetch-mock": "9.11.0",
     "ganache": "npm:@celo/ganache@7.8.0-unofficial.0",
     "jest": "^29.7.0",
-    "old-celo-base": "npm:@celo/base@5.0.0",
-    "old-identity-sdk": "npm:@celo/identity@1.5.2"
+    "@celo/base@5.0.0": "npm:@celo/base@5.0.0",
+    "@celo/identity@1.5.2": "npm:@celo/identity@1.5.2"
   },
   "engines": {
     "node": ">=16"

--- a/packages/identity/src/odis/identifier-backwards-compatibility.test.ts
+++ b/packages/identity/src/odis/identifier-backwards-compatibility.test.ts
@@ -1,10 +1,10 @@
-import { getPhoneHash } from 'old-celo-base'
+import { getPhoneHash } from '@celo/base@5.0.0'
+import { OdisUtils as OdisUtilsOld } from '@celo/identity@1.5.2'
 import { soliditySha3 } from '@celo/utils/lib/solidity'
-import { OdisUtils as OdisUtilsOld } from 'old-identity-sdk'
 import { OdisUtils } from '../../lib'
+import fetchMock from '../__mocks__/cross-fetch'
 import { WasmBlsBlindingClient } from './bls-blinding-client'
 import { AuthenticationMethod, AuthSigner, getServiceContext, OdisContextName } from './query'
-import fetchMock from '../__mocks__/cross-fetch'
 
 const { getBlindedIdentifier, getIdentifierHash, getObfuscatedIdentifier, IdentifierPrefix } =
   OdisUtils.Identifier

--- a/packages/identity/src/odis/identifier-backwards-compatibility.test.ts
+++ b/packages/identity/src/odis/identifier-backwards-compatibility.test.ts
@@ -1,6 +1,6 @@
-import { getPhoneHash } from '@celo/base@5.0.0'
-import { OdisUtils as OdisUtilsOld } from '@celo/identity@1.5.2'
+import { getPhoneHash } from '@celo/base'
 import { soliditySha3 } from '@celo/utils/lib/solidity'
+import { OdisUtils as OdisUtilsOld } from 'celo-identity-old-version'
 import { OdisUtils } from '../../lib'
 import fetchMock from '../__mocks__/cross-fetch'
 import { WasmBlsBlindingClient } from './bls-blinding-client'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,6 +1822,8 @@ __metadata:
     "@types/elliptic": "npm:^6.4.16"
     bignumber.js: "npm:^9.1.2"
     blind-threshold-bls: "npm:@celo/blind-threshold-bls@1.0.0-beta"
+    celo-base-old-version: "npm:@celo/base@5.0.0"
+    celo-identity-old-version: "npm:@celo/identity@1.5.2"
     cross-fetch: "npm:3.1.4"
     debug: "npm:^4.1.1"
     elliptic: "npm:^6.5.4"
@@ -1831,8 +1833,6 @@ __metadata:
     ganache: "npm:@celo/ganache@7.8.0-unofficial.0"
     io-ts: "npm:2.0.1"
     jest: "npm:^29.7.0"
-    old-celo-base: "npm:@celo/base@5.0.0"
-    old-identity-sdk: "npm:@celo/identity@1.5.2"
   languageName: unknown
   linkType: soft
 
@@ -5970,9 +5970,9 @@ __metadata:
   linkType: hard
 
 "@types/google-libphonenumber@npm:^7.4.17":
-  version: 7.4.26
-  resolution: "@types/google-libphonenumber@npm:7.4.26"
-  checksum: c6e0c76a2fd75f428824b28bf8c2e497a8b4502dbb4ddd85fb0bfb9bfff568dc5d2ff1fb67849316ebf74525e2f21b3661e421dd922e871e017d1c6bcc138f06
+  version: 7.4.30
+  resolution: "@types/google-libphonenumber@npm:7.4.30"
+  checksum: 70e90971a6218ab2900d29e801a85e59147d6af7b9fccfbb46df6846215d7e62aa1817c0f34c800080815eed2d4eda61a43a20353290db9429dc140ab6887356
   languageName: node
   linkType: hard
 
@@ -6210,10 +6210,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.14.104, @types/lodash@npm:^4.14.170":
+"@types/lodash@npm:^4.14.104":
   version: 4.14.198
   resolution: "@types/lodash@npm:4.14.198"
   checksum: 2bd7e82245cf0c66169ed074a2e625da644335a29f65c0c37d501cf66d09d8a0e92408e9e0ce4ee5133343e5b27267e6a132ca38a9ded837d4341be8a3cf8008
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:^4.14.170":
+  version: 4.14.202
+  resolution: "@types/lodash@npm:4.14.202"
+  checksum: 1bb9760a5b1dda120132c4b987330d67979c95dbc22612678682cd61b00302e190f4207228f3728580059cdab5582362262e3819aea59960c1017bd2b9fb26f6
   languageName: node
   linkType: hard
 
@@ -8647,18 +8654,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"celo-base-old-version@npm:@celo/base@5.0.0":
+  version: 5.0.0
+  resolution: "@celo/base@npm:5.0.0"
+  checksum: 5679cad0541cb07afda2c58b16a5195db8b9e6e24fa06c3be2cd40e5b4f148c2b35b9034f9a853676f6f50019f83304ee45ebbcaa988470870b3405ef6148193
+  languageName: node
+  linkType: hard
+
+"celo-identity-old-version@npm:@celo/identity@1.5.2":
+  version: 1.5.2
+  resolution: "@celo/identity@npm:1.5.2"
+  dependencies:
+    "@celo/base": "npm:1.5.2"
+    "@celo/contractkit": "npm:1.5.2"
+    "@celo/phone-number-privacy-common": "npm:1.0.39"
+    "@celo/utils": "npm:1.5.2"
+    "@types/debug": "npm:^4.1.5"
+    bignumber.js: "npm:^9.0.0"
+    blind-threshold-bls: "https://github.com/celo-org/blind-threshold-bls-wasm#e1e2f8a"
+    cross-fetch: "npm:3.0.4"
+    debug: "npm:^4.1.1"
+    elliptic: "npm:^6.5.4"
+    fp-ts: "npm:2.1.1"
+    io-ts: "npm:2.0.1"
+  checksum: f0cba55a458db511936a5b3fd0da1b78b3892457e76119f2e14a35dda6088122b303c72f7f489bf43463c15693b5dcb95eee1b1a825981f8e3fdae438e998bb5
+  languageName: node
+  linkType: hard
+
 "chai@npm:^4.2.0":
-  version: 4.3.8
-  resolution: "chai@npm:4.3.8"
+  version: 4.3.10
+  resolution: "chai@npm:4.3.10"
   dependencies:
     assertion-error: "npm:^1.1.0"
-    check-error: "npm:^1.0.2"
-    deep-eql: "npm:^4.1.2"
-    get-func-name: "npm:^2.0.0"
-    loupe: "npm:^2.3.1"
+    check-error: "npm:^1.0.3"
+    deep-eql: "npm:^4.1.3"
+    get-func-name: "npm:^2.0.2"
+    loupe: "npm:^2.3.6"
     pathval: "npm:^1.1.1"
-    type-detect: "npm:^4.0.5"
-  checksum: 0558ed535cc5c4b26c0f99f1408fd50834459f59d96c8dc5b75cc71c9d01710f04e70d8688f410a9e8c97cf9451b5f9ad98005d74611cee746b6a72364946940
+    type-detect: "npm:^4.0.8"
+  checksum: 9e545fd60f5efee4f06f7ad62f7b1b142932b08fbb3454db69defd511e7c58771ce51843764212da1e129b2c9d1b029fbf5f98da030fe67a95a0853e8679524f
   languageName: node
   linkType: hard
 
@@ -8704,10 +8738,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"check-error@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "check-error@npm:1.0.2"
-  checksum: 011e74b2eac49bd42c5610f15d6949d982e7ec946247da0276278a90e7476e6b88d25d3c605a4115d5e3575312e1f5a11e91c82290c8a47ca275c92f5d0981db
+"check-error@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "check-error@npm:1.0.3"
+  dependencies:
+    get-func-name: "npm:^2.0.2"
+  checksum: e2131025cf059b21080f4813e55b3c480419256914601750b0fee3bd9b2b8315b531e551ef12560419b8b6d92a3636511322752b1ce905703239e7cc451b6399
   languageName: node
   linkType: hard
 
@@ -9808,7 +9844,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-eql@npm:^4.1.2":
+"deep-eql@npm:^4.1.3":
   version: 4.1.3
   resolution: "deep-eql@npm:4.1.3"
   dependencies:
@@ -9908,7 +9944,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.1.2, define-properties@npm:^1.1.3, define-properties@npm:^1.1.4, define-properties@npm:^1.2.0":
+"define-properties@npm:^1.1.2":
+  version: 1.2.1
+  resolution: "define-properties@npm:1.2.1"
+  dependencies:
+    define-data-property: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.0"
+    object-keys: "npm:^1.1.1"
+  checksum: b4ccd00597dd46cb2d4a379398f5b19fca84a16f3374e2249201992f36b30f6835949a9429669ee6b41b6e837205a163eadd745e472069e70dfc10f03e5fcc12
+  languageName: node
+  linkType: hard
+
+"define-properties@npm:^1.1.3, define-properties@npm:^1.1.4, define-properties@npm:^1.2.0":
   version: 1.2.0
   resolution: "define-properties@npm:1.2.0"
   dependencies:
@@ -9976,12 +10023,12 @@ __metadata:
   linkType: hard
 
 "des.js@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "des.js@npm:1.0.1"
+  version: 1.1.0
+  resolution: "des.js@npm:1.1.0"
   dependencies:
     inherits: "npm:^2.0.1"
     minimalistic-assert: "npm:^1.0.0"
-  checksum: f8eed334f85228d0cd985e3299c9e65ab70f6b82852f4dfb3eb2614ec7927ece262fed172daca02b57899388477046739225663739e54185d90cc5e5c10b4e11
+  checksum: d35fc82b5a0b2127b12699212e90b54ddd8134e0cf8d27a8c30507ed3572aa574ab71800cbb473769128a52dcf21acc3271c5c359508a5aa772e990df3b1a698
   languageName: node
   linkType: hard
 
@@ -14904,7 +14951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keccak@npm:*":
+"keccak@npm:*, keccak@npm:^3.0.2":
   version: 3.0.4
   resolution: "keccak@npm:3.0.4"
   dependencies:
@@ -14916,7 +14963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keccak@npm:^3.0.0, keccak@npm:^3.0.2":
+"keccak@npm:^3.0.0":
   version: 3.0.3
   resolution: "keccak@npm:3.0.3"
   dependencies:
@@ -15513,12 +15560,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loupe@npm:^2.3.1":
-  version: 2.3.6
-  resolution: "loupe@npm:2.3.6"
+"loupe@npm:^2.3.6":
+  version: 2.3.7
+  resolution: "loupe@npm:2.3.7"
   dependencies:
-    get-func-name: "npm:^2.0.0"
-  checksum: 8e695f3c99d9670d524767bc2bcbf799444b865d1d05e974d6dc53d72863c2ce9990103f311f89f04019f064e5ae7bbe70f3fba030a57d65aacfb951aad34d9f
+    get-func-name: "npm:^2.0.1"
+  checksum: 635c8f0914c2ce7ecfe4e239fbaf0ce1d2c00e4246fafcc4ed000bfdb1b8f89d05db1a220054175cca631ebf3894872a26fffba0124477fcb562f78762848fb1
   languageName: node
   linkType: hard
 
@@ -16551,7 +16598,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.10.6, moment@npm:^2.19.3":
+"moment@npm:^2.10.6":
+  version: 2.30.1
+  resolution: "moment@npm:2.30.1"
+  checksum: ae42d876d4ec831ef66110bdc302c0657c664991e45cf2afffc4b0f6cd6d251dde11375c982a5c0564ccc0fa593fc564576ddceb8c8845e87c15f58aa6baca69
+  languageName: node
+  linkType: hard
+
+"moment@npm:^2.19.3":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 157c5af5a0ba8196e577bc67feb583303191d21ba1f7f2af30b3b40d4c63a64d505ba402be2a1454832082fac6be69db1e0d186c3279dae191e6634b0c33705c
@@ -16714,21 +16768,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.13.2, nan@npm:^2.14.0":
-  version: 2.17.0
-  resolution: "nan@npm:2.17.0"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: bba1efee2475afb0cce154300b554863fb4bb0a683a28f5d0fa7390794b3b4381356aabeab6472c70651d9c8a2830e7595963f3ec0aa2008e5c4d83dbeb820fa
-  languageName: node
-  linkType: hard
-
-"nan@npm:^2.18.0":
+"nan@npm:^2.13.2, nan@npm:^2.18.0":
   version: 2.18.0
   resolution: "nan@npm:2.18.0"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 5520e22c64e2b5b495b1d765d6334c989b848bbe1502fec89c5857cabcc7f9f0474563377259e7574bff1c8a041d3b90e9ffa1f5e15502ffddee7b2550cc26a0
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.14.0":
+  version: 2.17.0
+  resolution: "nan@npm:2.17.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: bba1efee2475afb0cce154300b554863fb4bb0a683a28f5d0fa7390794b3b4381356aabeab6472c70651d9c8a2830e7595963f3ec0aa2008e5c4d83dbeb820fa
   languageName: node
   linkType: hard
 
@@ -17266,33 +17320,6 @@ __metadata:
     typescript: "npm:^5.2.2"
   languageName: unknown
   linkType: soft
-
-"old-celo-base@npm:@celo/base@5.0.0":
-  version: 5.0.0
-  resolution: "@celo/base@npm:5.0.0"
-  checksum: 5679cad0541cb07afda2c58b16a5195db8b9e6e24fa06c3be2cd40e5b4f148c2b35b9034f9a853676f6f50019f83304ee45ebbcaa988470870b3405ef6148193
-  languageName: node
-  linkType: hard
-
-"old-identity-sdk@npm:@celo/identity@1.5.2":
-  version: 1.5.2
-  resolution: "@celo/identity@npm:1.5.2"
-  dependencies:
-    "@celo/base": "npm:1.5.2"
-    "@celo/contractkit": "npm:1.5.2"
-    "@celo/phone-number-privacy-common": "npm:1.0.39"
-    "@celo/utils": "npm:1.5.2"
-    "@types/debug": "npm:^4.1.5"
-    bignumber.js: "npm:^9.0.0"
-    blind-threshold-bls: "https://github.com/celo-org/blind-threshold-bls-wasm#e1e2f8a"
-    cross-fetch: "npm:3.0.4"
-    debug: "npm:^4.1.1"
-    elliptic: "npm:^6.5.4"
-    fp-ts: "npm:2.1.1"
-    io-ts: "npm:2.0.1"
-  checksum: f0cba55a458db511936a5b3fd0da1b78b3892457e76119f2e14a35dda6088122b303c72f7f489bf43463c15693b5dcb95eee1b1a825981f8e3fdae438e998bb5
-  languageName: node
-  linkType: hard
 
 "on-finished@npm:2.4.1, on-finished@npm:^2.2.0":
   version: 2.4.1
@@ -21215,7 +21242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8, type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
+"type-detect@npm:4.0.8, type-detect@npm:^4.0.0, type-detect@npm:^4.0.8":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 5179e3b8ebc51fce1b13efb75fdea4595484433f9683bbc2dca6d99789dba4e602ab7922d2656f2ce8383987467f7770131d4a7f06a26287db0615d2f4c4ce7d


### PR DESCRIPTION
### Description

Using the alias `old-identity-sdk` falsely flags that the `@celo/identity` SDK uses a malicious NPM package with the name `old-identity-sdk`. See: https://socket.dev/npm/package/old-identity-sdk/files/1.5.2/index.js

It's a misunderstanding, because `old-identity-sdk` is only an alias for a previous version of `@celo/identity` and not actually importing the malicious package. But, to avoid having a bad score on socket.dev, I propose changing the alias.

```json
{
  "devDependencies": {
    "old-identity-sdk": "npm:@celo/identity@1.5.2"
  },
}
```

<img width="450" src="https://github.com/celo-org/social-connect/assets/46296830/eae8937d-1362-435e-ad9e-5e0cb6a3f8a0">

### Tested

Trying to run the backwards compatibility test with `yarn test`, but struggling to run that command.

- [ ] Currently debugging

### Related issues

N/A

### Backwards compatibility

Changes are backwards compatible, this is a simple variable name change.

### Documentation

N/A