### PR TITLE
chore: Add missing deps

### DIFF
--- a/apps/combiner/package.json
+++ b/apps/combiner/package.json
@@ -35,7 +35,7 @@
     "@opentelemetry/exporter-jaeger": "^1.17.1",
     "@opentelemetry/instrumentation": "^0.44.0",
     "@opentelemetry/propagator-ot-trace": "^0.27.0",
-    "@opentelemetry/resources": "1.17.1",
+    "@opentelemetry/resources": "^1.17.1",
     "@opentelemetry/sdk-metrics": "^1.17.1",
     "@opentelemetry/sdk-node": "^0.44.0",
     "@opentelemetry/sdk-trace-base": "^1.17.1",

--- a/apps/monitor/package.json
+++ b/apps/monitor/package.json
@@ -36,10 +36,12 @@
     "yargs": "^14.0.0"
   },
   "devDependencies": {
+    "@types/node": "22.16.5",
     "firebase-functions-test": "^3.1.0",
     "firebase-tools": "13.6.0",
     "jest": "^29.7.0",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": "22"

--- a/apps/signer/package.json
+++ b/apps/signer/package.json
@@ -50,7 +50,7 @@
     "@opentelemetry/exporter-jaeger": "^1.17.1",
     "@opentelemetry/instrumentation": "^0.44.0",
     "@opentelemetry/propagator-ot-trace": "^0.27.0",
-    "@opentelemetry/resources": "1.17.1",
+    "@opentelemetry/resources": "^1.17.1",
     "@opentelemetry/sdk-metrics": "^1.17.1",
     "@opentelemetry/sdk-node": "^0.44.0",
     "@opentelemetry/sdk-trace-base": "^1.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,7 +911,7 @@ __metadata:
     "@opentelemetry/exporter-jaeger": "npm:^1.17.1"
     "@opentelemetry/instrumentation": "npm:^0.44.0"
     "@opentelemetry/propagator-ot-trace": "npm:^0.27.0"
-    "@opentelemetry/resources": "npm:1.17.1"
+    "@opentelemetry/resources": "npm:^1.17.1"
     "@opentelemetry/sdk-metrics": "npm:^1.17.1"
     "@opentelemetry/sdk-node": "npm:^0.44.0"
     "@opentelemetry/sdk-trace-base": "npm:^1.17.1"
@@ -1037,7 +1037,7 @@ __metadata:
     "@opentelemetry/exporter-jaeger": "npm:^1.17.1"
     "@opentelemetry/instrumentation": "npm:^0.44.0"
     "@opentelemetry/propagator-ot-trace": "npm:^0.27.0"
-    "@opentelemetry/resources": "npm:1.17.1"
+    "@opentelemetry/resources": "npm:^1.17.1"
     "@opentelemetry/sdk-metrics": "npm:^1.17.1"
     "@opentelemetry/sdk-node": "npm:^0.44.0"
     "@opentelemetry/sdk-trace-base": "npm:^1.17.1"
@@ -2975,6 +2975,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/core@npm:1.30.1":
+  version: 1.30.1
+  resolution: "@opentelemetry/core@npm:1.30.1"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:1.28.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10/fa3df9619fdbf8f607132d72915849754b71c4c5f5f705b30c8c59b209abe97206decf25cb8ebafdbb6105a4baab2acddee47468cb9d0b67f1a8df96cebc3548
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-jaeger@npm:1.17.1":
   version: 1.17.1
   resolution: "@opentelemetry/exporter-jaeger@npm:1.17.1"
@@ -3770,6 +3781,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/resources@npm:^1.17.1":
+  version: 1.30.1
+  resolution: "@opentelemetry/resources@npm:1.30.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/semantic-conventions": "npm:1.28.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10/9b7544b639e8fee41315e2646615676ffb1020dba0f6c81e6ec1dd2daf5409fc6ce3d2b629bbd9cd32f85decc3a8bfa5dc8cc52bb72bd84c1777ca25b4301aa0
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-logs@npm:0.44.0":
   version: 0.44.0
   resolution: "@opentelemetry/sdk-logs@npm:0.44.0"
@@ -3899,6 +3922,13 @@ __metadata:
   version: 1.22.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.22.0"
   checksum: 10/6dd21678bebe1ee78cea2d52cbccaac457694cb92f143c1692c109a89d070d8bc5e39f7a7f777c0e855a9393f6cc6f682ce771705e5042d037486c11e8d3a60c
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.28.0":
+  version: 1.28.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.28.0"
+  checksum: 10/c182a3206769b5d5a8ab89a5c674d046fd789421cef27ea55af179990e314732433c98e5017aa23e99f15fd2b0e13cb129bb6c2282da6860ce9419adf32b2e87
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,12 +1009,14 @@ __metadata:
     "@celo/phone-number-privacy-common": "npm:^3.1.2"
     "@celo/utils": "npm:^6.0.0"
     "@celo/wallet-local": "npm:^5.1.2"
+    "@types/node": "npm:22.16.5"
     firebase-admin: "npm:^11.11.0"
     firebase-functions: "npm:^4.5.0"
     firebase-functions-test: "npm:^3.1.0"
     firebase-tools: "npm:13.6.0"
     jest: "npm:^29.7.0"
     ts-node: "npm:^10.9.1"
+    typescript: "npm:^5.2.2"
     yargs: "npm:^14.0.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
➤ YN0002: │ @celo/phone-number-privacy-monitor@workspace:apps/monitor doesn't provide @types/node (pfd94e), requested by ts-node. ➤ YN0002: │ @celo/phone-number-privacy-monitor@workspace:apps/monitor doesn't provide typescript (p95c9f), requested by ts-node.
