### PR TITLE
docs(readme): add Twitter numeric ID identifier examples and fix plainTextIdentifier FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,74 @@ The [emisianto web app](https://emisianto.vercel.app/) is a sample implementatio
 
 <img width="500" alt="image" src="https://user-images.githubusercontent.com/46296830/205343775-60e429ea-f5e5-42b2-9474-8ca7dfe842cc.png">
 
+## 🐦 Using Twitter / X Identifiers
+
+The Quickstart above uses a phone number (`+12345678910`) as the `userPlaintextIdentifier`. Twitter handles work the same way — with one important difference: **use the account's numeric user ID, not the display handle**.
+
+```ts
+// ✅ Correct — numeric user ID is stable; it never changes even if the handle does
+const userPlaintextIdentifier = "1234567890";  // Twitter numeric user ID
+const prefix = OdisUtils.Identifier.IdentifierPrefix.TWITTER; // resolves to "twit"
+
+// ❌ Avoid — display handles can be changed or claimed by someone else
+// const userPlaintextIdentifier = "alice";
+```
+
+Using the numeric ID prevents handle-squatting: if a user changes their Twitter handle, their existing attestation (registered under the numeric ID) remains valid. An attacker who later claims the old handle gets a different numeric ID and cannot inherit the attestation.
+
+### Full example: register a Twitter attestation
+
+```ts
+import { OdisUtils } from "@celo/identity";
+
+// Numeric user ID — fetch this from the Twitter/X API during your verification flow
+const twitterUserId = "1234567890";
+const userAccountAddress = "0x000000000000000000000000000000000000user";
+const attestationVerifiedTime = Date.now();
+
+// Step 1: derive the obfuscated identifier via ODIS
+const { obfuscatedIdentifier } =
+  await OdisUtils.Identifier.getObfuscatedIdentifier(
+    twitterUserId,
+    OdisUtils.Identifier.IdentifierPrefix.TWITTER, // "twit"
+    issuerAddress,
+    authSigner,
+    serviceContext
+  );
+
+// Step 2: register on-chain
+await federatedAttestationsContract
+  .registerAttestationAsIssuer(
+    obfuscatedIdentifier,
+    userAccountAddress,
+    attestationVerifiedTime
+  )
+  .send();
+```
+
+### Full example: look up an address by Twitter user ID
+
+```ts
+const { obfuscatedIdentifier } =
+  await OdisUtils.Identifier.getObfuscatedIdentifier(
+    twitterUserId,                                  // numeric ID, not handle
+    OdisUtils.Identifier.IdentifierPrefix.TWITTER,
+    issuerAddress,
+    authSigner,
+    serviceContext
+  );
+
+const attestations = await federatedAttestationsContract.lookupAttestations(
+  obfuscatedIdentifier,
+  [issuerAddress]  // only trust attestations from issuers you control or whitelist
+);
+
+// attestations.accounts[0] is the on-chain address linked to this Twitter user ID
+console.log(attestations.accounts);
+```
+
+> **Note:** `IdentifierPrefix.TWITTER` resolves to the string `"twit"`. The obfuscated identifier is derived as `sha3(sha3("twit://{twitterUserId}")__{pepper})`. See [`packages/odis-identifiers/src/identifier.ts`](packages/odis-identifiers/src/identifier.ts) for all supported prefixes.
+
 ## 📄 Documentation
 
 For a deeper dive under the hood and specific implementation details, check out the documentation of the [protocol](docs/protocol.md) for details on how to interact with the on-chain registry, [privacy](docs/privacy.md) for how identifiers are obfuscated, and [key-setup](docs/key-setup.md) to setup your role keys to interact with the protocol.

--- a/README.md
+++ b/README.md
@@ -259,11 +259,13 @@ Interested in Integrating SocialConnect, get in touch by filling this [form](htt
 <details>
   <summary>What is a "plainTextIdentifier"?</summary>
 
-`plainTextIdentifier` is any string of text that a user can use to identify other user.
+`plainTextIdentifier` is any string of text that a user can use to identify another user.
 
-Phone number, Twitter handle, GitHub username anything that makes it easier to represent an evm based address.
+Phone number, GitHub username, Discord handle — anything that makes it easier to represent an EVM address.
 
-For example:- Alice's phone number: `+12345678901`
+For example: Alice's phone number: `+12345678901`
+
+For Twitter/X, use the **numeric user ID** (e.g. `"1234567890"`), not the display handle (e.g. `"alice"`). Display handles can be changed or transferred to another account; the numeric ID is permanent and prevents a new owner of a handle from inheriting existing attestations.
 
 </details>
 


### PR DESCRIPTION
## What changed

**`README.md`** — two commits

### Commit 1: new `## 🐦 Using Twitter / X Identifiers` section
Added between `## 🚀 Examples` and `## 📄 Documentation`. Contains:
- Explanation of why to use the numeric user ID instead of the display handle (handles are transferable; numeric IDs are permanent)
- A side-by-side correct/incorrect code comment showing `"1234567890"` vs `"alice"`
- Full working example for **registering** a Twitter attestation using `IdentifierPrefix.TWITTER`
- Full working example for **looking up** an address by Twitter user ID
- A note that `IdentifierPrefix.TWITTER` resolves to the string `"twit"` and a link to `identifier.ts` for all supported prefixes

### Commit 2: fix `plainTextIdentifier` FAQ entry
- Corrected minor grammar
- Removed the Twitter handle as a positive example (it was listed alongside phone numbers without any caveat)
- Added an explicit note that for Twitter/X, developers should use the numeric user ID, not the display handle, with the reason

## Why

The Quickstart section uses only phone number examples throughout. Twitter is listed as a supported identifier type in the intro and in the Examples table (`SocialConnect-Twitter` repos), but there is no working code example in the README showing how to actually use it. A developer following the Quickstart to implement Twitter-based attestations would have no guidance on:

1. Which `IdentifierPrefix` to pass (`TWITTER`, which resolves to `"twit"` — not `"twitter"`)
2. Whether to pass the display handle or numeric user ID as `plaintextIdentifier`

The FAQ entry for `plainTextIdentifier` listed "Twitter handle" as an example without any caveat, which would lead developers to register attestations under a mutable string. If the user later changes their handle and someone else claims it, that new account would resolve the same obfuscated identifier.

## How to verify

1. Search the README for `IdentifierPrefix.TWITTER` — two complete, runnable code blocks should appear
2. Search for `"twit"` — the inline note explaining the resolved string value should appear
3. Search for `numeric` — should appear in both the new section and the updated FAQ entry
4. Confirm `IdentifierPrefix.TWITTER = twit` at [`packages/odis-identifiers/src/identifier.ts#L25`](packages/odis-identifiers/src/identifier.ts)